### PR TITLE
Change default egg display setting

### DIFF
--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -63,7 +63,7 @@ Settings.add(new Setting<string>('breedingDisplay', 'Breeding progress display',
         new SettingOption('Percentage', 'percentage'),
         new SettingOption('Step count', 'stepCount'),
     ],
-    'percentage'));
+    'stepCount'));
 Settings.add(new Setting<string>('shopButtons', 'Shop amount buttons',
     [
         new SettingOption('+10, +100', 'original'),


### PR DESCRIPTION
Right now the default setting is percentage wich don't give information and can be confusing for new player (have seen 2 confusions with it only today) so if accepted it would make steps as default
Did you mean that pixl? XD