### PR TITLE
Indicate achievement bonus in subregions

### DIFF
--- a/src/components/achievementsModal.html
+++ b/src/components/achievementsModal.html
@@ -3,7 +3,7 @@ aria-labelledby="AchievementsModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to: 150% (global), 100% (per region), and 50% (per special subregion). Earning bonuses to Click Attack, Flute Effects, Pokédollar / Dungeon Token gains, and Experience earned from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
+                <h5 data-bind="tooltip: { title: 'As you earn achievements, you gain up to: 150% (global), 100% (per region), and from 25% to 50% (per special subregion). Earning bonuses to Click Attack, Flute Effects, Pokédollar / Dungeon Token gains, and Experience earned from all sources.', trigger: 'hover', placement:'right' }">Achievements Bonus: <u class="text-primary" data-bind="text: AchievementHandler.achievementBonusPercent()"></u></h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                   <span aria-hidden="true">&times;</span>
                 </button>


### PR DESCRIPTION
Splashing news! Fishes are everywhere! A new island appeared in alola full of Magikarps! Our heroes are there fighting krap karps and getting achievements! But.... How much achievements are they getting? Modal say 50% per region but ¡NO! It is 25... Luckily an expert of change only 1 word in code have decided to change saying from 25% to 50% with the option to change from 25 to 75 when hisui came out (Soon:tm:)... Our heorues are saved! 